### PR TITLE
Refactor DBT Profiles: Set Default Auth to 'BasicAuth' & Rename 'database' to 'catalog'

### DIFF
--- a/.changes/unreleased/Changed-20250211-144522.yaml
+++ b/.changes/unreleased/Changed-20250211-144522.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: Set default authentication method to 'BasicAuth' and rename 'database' to 'catalog' in DBT profiles for consistency with wxd terminology.
+time: 2025-02-11T14:45:22.389836+05:30
+custom:
+  Author: KNagaVivek
+  PR: "25"

--- a/dbt/adapters/presto/connections.py
+++ b/dbt/adapters/presto/connections.py
@@ -57,7 +57,7 @@ class PrestoCredentials(Credentials):
     port: Port
     user: str
     password: Optional[str] = None
-    method: Optional[str] = None
+    method: Optional[str] = "BasicAuth"
     http_headers: Optional[Dict[str, str]] = None
     http_scheme: Optional[str] = None
     ssl_verify: Optional[Union[bool, str]] = True
@@ -200,7 +200,7 @@ class PrestoConnectionManager(SQLConnectionManager):
             return connection
 
         credentials = connection.credentials
-        if credentials.method == 'BasicAuth':
+        if credentials.method.lower() == "basicauth":
             auth = prestodb.auth.BasicAuthentication(
                 credentials.user,
                 credentials.password,

--- a/dbt/include/presto/sample_profiles.yml
+++ b/dbt/include/presto/sample_profiles.yml
@@ -3,7 +3,7 @@ default:
 
     dev:
       type: presto
-      method: none  # optional, one of {none | BasicAuth}
+      method: BasicAuth  # one of {none | BasicAuth}
       user: [dev_user]
       password: [password]  # required if method is BasicAuth
       database: [database name]
@@ -14,7 +14,7 @@ default:
 
     prod:
       type: presto
-      method: none  # optional, one of {none | BasicAuth}
+      method: BasicAuth  # one of {none | BasicAuth}
       user: [prod_user]
       password: [prod_password]  # required if method is BasicAuth
       database: [database name]

--- a/dbt/include/presto/sample_profiles.yml
+++ b/dbt/include/presto/sample_profiles.yml
@@ -6,9 +6,9 @@ default:
       method: BasicAuth  # one of {none | BasicAuth}
       user: [dev_user]
       password: [password]  # required if method is BasicAuth
-      database: [database name]
       host: [hostname]
-      port: [port number]
+      port: [port_number]
+      catalog: [catalog_name]
       schema: [dev_schema]
       threads: [1 or more]
 
@@ -17,9 +17,9 @@ default:
       method: BasicAuth  # one of {none | BasicAuth}
       user: [prod_user]
       password: [prod_password]  # required if method is BasicAuth
-      database: [database name]
       host: [hostname]
-      port: [port number]
+      port: [port_number]
+      catalog: [catalog_name]
       schema: [prod_schema]
       threads: [1 or more]
   


### PR DESCRIPTION
- **Updated Authentication**: Set the default authentication method to `BasicAuth`.
- **Terminology Alignment**: Renamed the database parameter to catalog in DBT profiles to match wxd terminology.

